### PR TITLE
WallMesh construction moved to Game constructor

### DIFF
--- a/source/Game.cpp
+++ b/source/Game.cpp
@@ -5,6 +5,7 @@
 #include "SceneStart.hpp"
 #include "Joystick.hpp"
 #include "PyPlugin.hpp"
+#include "LevelScene.hpp"
 
 // Constructor
 
@@ -34,6 +35,9 @@ Game::Game()
   // Font loading
   Ogre::FontPtr font = Ogre::FontManager::getSingletonPtr()->getByName("HUD/Font");
   font->load();
+
+  // Loading wall mesh
+  LevelScene::createWallMesh();
 
   // Go to start screen
   renderer->doSwitchScene(Renderer::SceneSwitcherException([this]() {

--- a/source/UIOverlaySelection.cpp
+++ b/source/UIOverlaySelection.cpp
@@ -129,7 +129,6 @@ UIOverlaySelection::UIOverlaySelection(Renderer &renderer)
 	  }
 	}
       }
-      LevelScene::createWallMesh();
       return static_cast<Scene *>(new LevelScene(renderer, v, classes, gameplays));
     });
   }, bwidth, UIOverlaySelection::SELECTIONBUTTON_HEIGHT, 0.0f));


### PR DESCRIPTION
Fix crash when launching multiple times the game, because 'wall mesh' was created each time